### PR TITLE
pub mod address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ use std::marker::PhantomData;
 mod tree_bitmap;
 use tree_bitmap::TreeBitmap;
 
-mod address;
+pub mod address;
 use address::Address;
 
 #[cfg(feature = "alloc")]


### PR DESCRIPTION
Allow users to `impl Address` for their own types. This would resolve hroi/treebitmap#8